### PR TITLE
Adjust progress dialog handling

### DIFF
--- a/Proyecto1EstructurasDeDatos/MainWindow.cpp
+++ b/Proyecto1EstructurasDeDatos/MainWindow.cpp
@@ -171,7 +171,6 @@ void MainWindow::connectSignals() {
 }
 
 void MainWindow::showBusy() {
-    progress->reset();
     progress->setLabelText("Traduciendo...");
     progress->setRange(0, 0);
     progress->adjustSize();
@@ -185,7 +184,7 @@ void MainWindow::showBusy() {
 
 void MainWindow::hideBusy() {
     progress->hide();
-    progress->reset();
+    progress->setMinimumDuration(std::numeric_limits<int>::max());
 }
 
 void MainWindow::translateAllLines() {


### PR DESCRIPTION
## Summary
- stop resetting the translation progress dialog before showing it to avoid spurious reactivation
- keep the progress dialog hidden without resetting by restoring the long minimum duration

## Testing
- not run (GUI application)

------
https://chatgpt.com/codex/tasks/task_e_68d853448910832cb147145cc54f4432