### PR TITLE
Normalize instruction parsing and support simple if

### DIFF
--- a/Proyecto1EstructurasDeDatos/InstructionProcessor.cpp
+++ b/Proyecto1EstructurasDeDatos/InstructionProcessor.cpp
@@ -20,109 +20,167 @@ Instruction InstructionProcessor::parseInstruction(string lineText) {
     int indentSpaces = countLeadingIndentSpaces(lineText);
     string content = lineText.substr(indentSpaces);    
     string lowered = helper.toLowerSimple(content);
+    string normalized = helper.removeAccents(lowered);
     string original = content;
+    string trimmedOriginal = helper.trimSimple(original);
+    string trimmedNormalized = helper.removeAccents(helper.toLowerSimple(trimmedOriginal));
 
-    if (dict.hasComment(lowered)) {
-        string rest = helper.cutAfter(original, "comentario");
+    auto cutAfterInsensitive = [&](const string& pattern) -> string {
+        int pos = (int)lowered.find(pattern);
+        if (pos < 0) { return original; }
+        int begin = pos + (int)pattern.length();
+        if (begin < 0) { begin = 0; }
+        if (begin > (int)original.length()) { return string(""); }
+        return original.substr(begin);
+    };
+
+    auto cutBetweenInsensitive = [&](const string& start, const string& end) -> string {
+        int startPos = (int)lowered.find(start);
+        if (startPos < 0) { return string(""); }
+        int begin = startPos + (int)start.length();
+        if (begin < 0) { begin = 0; }
+        if (begin > (int)original.length()) { return string(""); }
+        int endPos = -1;
+        if (end != "") {
+            endPos = (int)lowered.find(end, begin);
+        }
+        if (endPos < 0) {
+            return helper.trimSimple(original.substr(begin));
+        }
+        return helper.trimSimple(original.substr(begin, endPos - begin));
+    };
+
+    if (dict.hasComment(normalized)) {
+        string rest = cutAfterInsensitive("comentario");
         Instruction ins("Meta", "comment", helper.trimSimple(rest));
         ins.setIndent(indentSpaces);
         return ins;
     }
-    if (dict.hasBeginProgram(lowered)) {
+    if (dict.hasBeginProgram(normalized)) {
         Instruction ins("Meta", "begin_program", "");
         ins.setIndent(indentSpaces);
         return ins;
     }
-    if (dict.hasEndProgram(lowered)) {
+    if (dict.hasEndProgram(normalized)) {
         Instruction ins("Meta", "end_program", "");
         ins.setIndent(indentSpaces);
         return ins;
     }
 
-    if (dict.hasDefineFunction(lowered)) {
-        string rest = helper.cutAfter(original, "definir funcion");
+    if (dict.hasDefineFunction(normalized)) {
+        string rest = cutAfterInsensitive("definir funcion");
+        if (rest == original) {
+            rest = cutAfterInsensitive("definir función");
+        }
         Instruction ins("Func", "def_func", helper.trimSimple(rest));
         ins.setIndent(indentSpaces);
         return ins;
     }
-    if (dict.hasCallFunction(lowered)) {
-        string rest = helper.cutAfter(original, "llamar funcion");
+    if (dict.hasCallFunction(normalized)) {
+        string rest = cutAfterInsensitive("llamar funcion");
+        if (rest == original) {
+            rest = cutAfterInsensitive("llamar función");
+        }
         Instruction ins("Func", "call_func", helper.trimSimple(rest));
         ins.setIndent(indentSpaces);
         return ins;
     }
 
-    if (dict.hasIfThen(lowered)) {
-        string cond = helper.cutBetweenSimple(original, "si", " entonces");
-        if (cond == "") { cond = helper.cutBetweenSimple(original, "si", "entonces"); }
+    bool startsWithSimpleIf = false;
+    if ((int)trimmedNormalized.length() >= 3) {
+        if (trimmedNormalized.rfind("si ", 0) == 0 && (int)trimmedNormalized.find(" entonces") < 0) {
+            startsWithSimpleIf = true;
+        }
+        else if (trimmedNormalized.rfind("si(", 0) == 0 && (int)trimmedNormalized.find(" entonces") < 0) {
+            startsWithSimpleIf = true;
+        }
+    }
+
+    if (dict.hasIfThen(normalized) || startsWithSimpleIf) {
+        string cond = cutBetweenInsensitive("si", " entonces");
+        if (cond == "") { cond = cutBetweenInsensitive("si", "entonces"); }
+        if (cond == "" && startsWithSimpleIf) {
+            if ((int)trimmedOriginal.length() > 2) {
+                cond = helper.trimSimple(trimmedOriginal.substr(2));
+            }
+        }
+        if (cond == "") {
+            cond = helper.trimSimple(cutAfterInsensitive("si"));
+        }
         Instruction ins("Control", "if", helper.trimSimple(cond));
         ins.setIndent(indentSpaces);
         return ins;
     }
-    if (dict.hasElse(lowered)) {
+    if (dict.hasElse(normalized)) {
         Instruction ins("Control", "else", "");
         ins.setIndent(indentSpaces);
         return ins;
     }
-    if (dict.hasWhile(lowered)) {
-        string rest = helper.cutAfter(original, "mientras");
+    if (dict.hasWhile(normalized)) {
+        string rest = cutAfterInsensitive("mientras");
         Instruction ins("Control", "while", helper.trimSimple(rest));
         ins.setIndent(indentSpaces);
         return ins;
     }
-    if (dict.hasDoUntil(lowered)) {
-        string rest = helper.cutAfter(original, "repetir hasta");
+    if (dict.hasDoUntil(normalized)) {
+        string rest = cutAfterInsensitive("repetir hasta");
         Instruction ins("Control", "do_until", helper.trimSimple(rest));
         ins.setIndent(indentSpaces);
         return ins;
     }
-    if (dict.hasForTo(lowered)) {
-        string left = helper.cutBetweenSimple(original, "para", " hasta");
-        if (left == "") { left = helper.cutBetweenSimple(original, "para", "hasta"); }
-        string right = helper.trimSimple(helper.cutAfter(original, "hasta"));
+    if (dict.hasForTo(normalized)) {
+        string left = cutBetweenInsensitive("para", " hasta");
+        if (left == "") { left = cutBetweenInsensitive("para", "hasta"); }
+        string right = helper.trimSimple(cutAfterInsensitive("hasta"));
         string joined = helper.trimSimple(left) + string(" ") + right; // "i = 1 5"
         Instruction ins("Control", "for_to", helper.trimSimple(joined));
         ins.setIndent(indentSpaces);
         return ins;
     }
 
-    if (dict.hasTraverseList(lowered)) {
-        string rest = helper.cutAfter(original, "recorrer la lista");
+    if (dict.hasTraverseList(normalized)) {
+        string rest = cutAfterInsensitive("recorrer la lista");
         Instruction ins("Array", "traverse_list", helper.trimSimple(rest));
         ins.setIndent(indentSpaces);
         return ins;
     }
-    if (dict.hasAddToList(lowered)) {
-        string rest = helper.cutAfter(original, "agregar a la lista");
+    if (dict.hasAddToList(normalized)) {
+        string rest = cutAfterInsensitive("agregar a la lista");
         Instruction ins("Array", "add_to_list", helper.trimSimple(rest));
         ins.setIndent(indentSpaces);
         return ins;
     }
-    if (dict.hasReadInput(lowered)) {
-        string rest = helper.cutAfter(original, "leer");
+    if (dict.hasReadInput(normalized)) {
+        string rest = original;
+        if ((int)normalized.find("ingresar valor") >= 0) {
+            rest = cutAfterInsensitive("ingresar valor");
+        }
+        else {
+            rest = cutAfterInsensitive("leer");
+        }
         Instruction ins("IO", "read", helper.trimSimple(rest));
         ins.setIndent(indentSpaces);
         return ins;
     }
 
-    if (dict.hasCalculate(lowered)) {
-        string rest = helper.cutAfter(original, "calcular");
+    if (dict.hasCalculate(normalized)) {
+        string rest = cutAfterInsensitive("calcular");
         Instruction ins("Op", "calc", helper.trimSimple(rest));
         ins.setIndent(indentSpaces);
         return ins;
     }
 
-    string opKey = dict.findOpKey(lowered);
+    string opKey = dict.findOpKey(normalized);
     if (opKey != "") {
-        string rest = helper.cutAfter(original, opKey);
+        string rest = cutAfterInsensitive(opKey);
         Instruction ins("Op", dict.opCanonical(opKey), helper.trimSimple(rest));
         ins.setIndent(indentSpaces);
         return ins;
     }
 
-    string ioKey = dict.findIOKey(lowered);
+    string ioKey = dict.findIOKey(normalized);
     if (ioKey != "") {
-        string rest = helper.cutAfter(original, ioKey);
+        string rest = cutAfterInsensitive(ioKey);
         Instruction ins("IO", dict.ioCanonical(ioKey), helper.trimSimple(rest));
         ins.setIndent(indentSpaces);
         return ins;

--- a/Proyecto1EstructurasDeDatos/TextHelper.cpp
+++ b/Proyecto1EstructurasDeDatos/TextHelper.cpp
@@ -36,11 +36,48 @@ char TextHelper::toLowerAscii(char c) {
     return c;
 }
 
+char TextHelper::removeAccentChar(char c) {
+    switch (c) {
+    case '\xc1': // Á
+    case '\xe1': // á
+        return 'a';
+    case '\xc9': // É
+    case '\xe9': // é
+        return 'e';
+    case '\xcd': // Í
+    case '\xed': // í
+        return 'i';
+    case '\xd3': // Ó
+    case '\xf3': // ó
+        return 'o';
+    case '\xda': // Ú
+    case '\xfa': // ú
+    case '\xdc': // Ü
+    case '\xfc': // ü
+        return 'u';
+    case '\xd1': // Ñ
+    case '\xf1': // ñ
+        return 'n';
+    default:
+        return c;
+    }
+}
+
 string TextHelper::toLowerSimple(string text) {
     int i = 0;
     int n = (int)text.length();
     while (i < n) {
         text[i] = toLowerAscii(text[i]);
+        i = i + 1;
+    }
+    return text;
+}
+
+string TextHelper::removeAccents(string text) {
+    int i = 0;
+    int n = (int)text.length();
+    while (i < n) {
+        text[i] = removeAccentChar(text[i]);
         i = i + 1;
     }
     return text;

--- a/Proyecto1EstructurasDeDatos/TextHelper.h
+++ b/Proyecto1EstructurasDeDatos/TextHelper.h
@@ -10,8 +10,10 @@ private:
     bool isSpaceSimple(char c);
     bool isDigitSimple(char c);
     char toLowerAscii(char c);
+    char removeAccentChar(char c);
 public:
     string toLowerSimple(string text);
+    string removeAccents(string text);
     string trimSimple(string text);
     int indexOfText(string text, string key);
     string cutAfter(string base, string key);


### PR DESCRIPTION
## Summary
- normalize instruction text before dictionary lookups to handle accented phrases
- add case-insensitive substring helpers so parsing works with capitalized commands
- support simple `Si` conditions and better extract variable names for `Ingresar valor`

## Testing
- not run (project configuration depends on Windows-specific toolchain)


------
https://chatgpt.com/codex/tasks/task_e_68d8d19660a0832c994e3e0a18733866