### PR TITLE
Enhance pseudocode support for lists, structs, and functions

### DIFF
--- a/Proyecto1EstructurasDeDatos/CodeGenerator.h
+++ b/Proyecto1EstructurasDeDatos/CodeGenerator.h
@@ -2,7 +2,10 @@
 #ifndef CODEGENERATOR_H
 #define CODEGENERATOR_H
 
+#include <map>
 #include <string>
+#include <utility>
+#include <vector>
 #include "Instruction.h"
 #include "VariableList.h"
 #include "LineList.h"
@@ -11,16 +14,38 @@ using namespace std;
 
 class CodeGenerator {
 private:
+    struct ArrayInfo {
+        string name;
+        string elementType;
+        int size;
+    };
+
+    struct StructInfo {
+        string name;
+        vector<pair<string, string>> fields;
+    };
+
     VariableList symbolTable;
     LineList preludeLines;
     LineList bodyLines;
     TextHelper helper;
+    map<string, ArrayInfo> arrayTable;
+    map<string, StructInfo> structTable;
+    ArrayInfo lastArrayInfo;
+    bool hasLastArray;
+    string lastLoopIndex;
+    string lastLoopArray;
+    LineList* activeLines;
+    bool insideFunction;
+    int functionIndent;
+    int functionBodyIndent;
 
     int arrayCounter;
     int lastIndent;
     int stackCount;
     int indentStack[64];
     string closeLineStack[64];
+    LineList* lineStack[64];
     bool headerJustEmitted;
     string nextCloseLine;
 
@@ -33,6 +58,18 @@ private:
 
     string normalizeMathTokens(string text);
     string normalizeConditionTokens(string text);
+    int effectiveIndent(int rawIndent);
+    string toLowerNoAccents(string text);
+    string normalizeBooleanWord(string text);
+    vector<string> splitPrintSegments(string text);
+    string detectArrayReference(string text);
+    ArrayInfo resolveArrayForText(string text);
+    string arraySizeExpression(const ArrayInfo& info);
+    string selectIndexName(string preferred);
+    void appendLine(const string& text);
+    void appendToPrelude(const string& text);
+    void registerArray(const ArrayInfo& info);
+    void registerStruct(const StructInfo& info);
     string removeSpaces(string text);
 
     bool splitAssignRight(string text, string& varName, string& value);
@@ -47,6 +84,10 @@ private:
     void genMul(string params);
     void genDiv(string params);
     void genCalc(string params);
+    void genSumAssign(string params);
+    void genSubAssign(string params);
+    void genMulAssign(string params);
+    void genDivAssign(string params);
 
     void genPrint(string params);
     void genMessage(string params);
@@ -64,6 +105,8 @@ private:
     void genCreateArray(string params);
     void genTraverseList(string params);
     void genAddToList(string params);
+    void genCreateStruct(string params);
+    void genReturn(string params);
 
     void genBeginProgram();
     void genEndProgram();

--- a/Proyecto1EstructurasDeDatos/LanguageDictionary.cpp
+++ b/Proyecto1EstructurasDeDatos/LanguageDictionary.cpp
@@ -21,6 +21,7 @@ LanguageDictionary::LanguageDictionary() {
     mapOp["lista de"] = "array_of";
     mapOp["recorrer la lista"] = "traverse_list";
     mapOp["agregar a la lista"] = "add_to_list";
+    mapOp["crear estructura"] = "create_struct";
 
     mapIO["imprimir"] = "print";
     mapIO["mostrar"] = "print";
@@ -39,6 +40,8 @@ LanguageDictionary::LanguageDictionary() {
     mapCtrl["comentario"] = "comment";
     mapCtrl["definir funcion"] = "def_func";
     mapCtrl["llamar funcion"] = "call_func";
+    mapCtrl["retornar"] = "return";
+    mapCtrl["retorne"] = "return";
 }
 
 string LanguageDictionary::findOpKey(string text) {


### PR DESCRIPTION
## Summary
- track arrays, structs, and function context in the code generator so it can emit loops for list input/traversal, struct definitions, return statements, and reassignment operators
- extend instruction parsing and the language dictionary to recognize arithmetic reassignment phrases, struct creation, and return commands used in the new pseudocode cases

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d8d78e1744832c83c59ea367a6ba5b