### PR TITLE
Handle non-breaking spaces and improve arithmetic code generation

### DIFF
--- a/Proyecto1EstructurasDeDatos/CodeGenerator.h
+++ b/Proyecto1EstructurasDeDatos/CodeGenerator.h
@@ -58,6 +58,8 @@ private:
 
     string normalizeMathTokens(string text);
     string normalizeConditionTokens(string text);
+    vector<string> extractMathOperands(string text);
+    string buildMathExpression(const vector<string>& operands, const string& op);
     int effectiveIndent(int rawIndent);
     string toLowerNoAccents(string text);
     string normalizeBooleanWord(string text);

--- a/Proyecto1EstructurasDeDatos/InstructionProcessor.cpp
+++ b/Proyecto1EstructurasDeDatos/InstructionProcessor.cpp
@@ -6,6 +6,15 @@ static int countLeadingIndentSpaces(string text) {
     int spaces = 0;
     while (i < n) {
         char c = text[i];
+        unsigned char uc = static_cast<unsigned char>(c);
+        if (uc == 0xC2 && i + 1 < n) {
+            unsigned char next = static_cast<unsigned char>(text[i + 1]);
+            if (next == 0xA0) { // non-breaking space
+                spaces = spaces + 1;
+                i = i + 2;
+                continue;
+            }
+        }
         if (c == ' ') { spaces = spaces + 1; i = i + 1; }
         else if (c == '\t') { spaces = spaces + 4; i = i + 1; }
         else { break; }

--- a/Proyecto1EstructurasDeDatos/TextHelper.cpp
+++ b/Proyecto1EstructurasDeDatos/TextHelper.cpp
@@ -1,6 +1,7 @@
 #include "TextHelper.h"
 
 bool TextHelper::isSpaceSimple(char c) {
+    unsigned char uc = static_cast<unsigned char>(c);
     if (c == ' ') {
         return true;
     }
@@ -17,6 +18,9 @@ bool TextHelper::isSpaceSimple(char c) {
         return true;
     }
     if (c == '\f') {
+        return true;
+    }
+    if (uc == 0xC2 || uc == 0xA0) {
         return true;
     }
     return false;


### PR DESCRIPTION
## Summary
- handle non-breaking spaces when counting indentation and trimming whitespace so nested blocks are detected correctly
- add helpers to parse arithmetic operands and generate cleaner sum, subtraction, multiplication, and division code
- reuse declared variables for arithmetic outputs to avoid invalid redeclarations during generation

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d8e1395ac8832c87aa33d96367c794