### PR TITLE
Choose available monospace font without Qt6-only API

### DIFF
--- a/Proyecto1EstructurasDeDatos/MainWindow.cpp
+++ b/Proyecto1EstructurasDeDatos/MainWindow.cpp
@@ -11,6 +11,7 @@
 #include <QScrollBar>
 #include <QFileInfo>
 #include <QStringList>
+#include <QFontDatabase>
 
 MainWindow::MainWindow(QWidget* parent)
     : QMainWindow(parent),
@@ -339,12 +340,35 @@ void MainWindow::buildUi() {
         btn->setCursor(Qt::PointingHandCursor);
     }
 
-    QFont mono(QStringLiteral("JetBrains Mono"));
-    mono.setStyleHint(QFont::Monospace);
-    mono.setFallbackFamilies(QStringList()
+    const QStringList candidateFamilies = QStringList()
+        << QStringLiteral("JetBrains Mono")
+        << QStringLiteral("Fira Code")
         << QStringLiteral("Consolas")
         << QStringLiteral("Courier New")
-        << QStringLiteral("DejaVu Sans Mono"));
+        << QStringLiteral("DejaVu Sans Mono");
+
+    QStringList availableFamilies;
+    for (const QString& family : candidateFamilies) {
+        if (QFontDatabase::hasFamily(family)) {
+            availableFamilies << family;
+        }
+    }
+
+    QFont mono;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    if (!availableFamilies.isEmpty()) {
+        mono.setFamilies(availableFamilies);
+    } else {
+        mono = QFontDatabase::systemFont(QFontDatabase::FixedFont);
+    }
+#else
+    if (!availableFamilies.isEmpty()) {
+        mono.setFamily(availableFamilies.first());
+    } else {
+        mono = QFontDatabase::systemFont(QFontDatabase::FixedFont);
+    }
+#endif
+    mono.setStyleHint(QFont::Monospace);
     mono.setPointSize(13);
     inputEdit->setFont(mono);
     codeEdit->setFont(mono);


### PR DESCRIPTION
## Summary
- look up a prioritized list of monospace font families and collect those installed on the system
- initialize the editor font from the available list or the system fixed font without relying on Qt 6 only APIs

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dcde0a1abc832cbb3d65649f78d573