### PR TITLE
Expand translator editors with drag-and-drop enhancements

### DIFF
--- a/Proyecto1EstructurasDeDatos/MainWindow.h
+++ b/Proyecto1EstructurasDeDatos/MainWindow.h
@@ -16,6 +16,13 @@
 #include <QGuiApplication>
 #include <QTimer>
 #include <QString>
+#include <QFrame>
+#include <QPropertyAnimation>
+#include <QParallelAnimationGroup>
+#include <QDragEnterEvent>
+#include <QDragLeaveEvent>
+#include <QDropEvent>
+#include <QResizeEvent>
 
 #include "InstructionProcessor.h"
 #include "CodeGenerator.h"
@@ -32,11 +39,15 @@ private:
     QLabel* subtitleLabel;
     QPlainTextEdit* inputEdit;
     QPlainTextEdit* codeEdit;
+    QLabel* dropOverlayLabel;
     QPushButton* loadButton;
     QPushButton* translateButton;
     QPushButton* exportButton;
     QPushButton* copyButton;
     QLabel* statusChip;
+    QSplitter* editorSplitter;
+    QFrame* leftCard;
+    QFrame* rightCard;
     InstructionProcessor processor;
     CodeGenerator generator;
     InstructionHighlighter* highlighter;
@@ -46,12 +57,22 @@ private:
     void buildUi();
     void applyDarkTheme();
     void connectSignals();
+    void initEntryAnimations();
+    void pulseButton(QPushButton* button);
+    void loadInstructionsFromFile(const QString& path);
     void translateAllLines();
     void updateInputMetrics();
     void setTranslatingState(bool active);
     void updateStatusLabel(const QString& stateText);
     void setStatusState(const QString& stateName);
     void scheduleStatusReset(int durationMs = 2200);
+    void updateDropOverlayGeometry();
+
+protected:
+    void dragEnterEvent(QDragEnterEvent* event) override;
+    void dragLeaveEvent(QDragLeaveEvent* event) override;
+    void dropEvent(QDropEvent* event) override;
+    void resizeEvent(QResizeEvent* event) override;
 
 private slots:
     void onLoadClicked();


### PR DESCRIPTION
## Summary
- enlarge and restyle the natural language and generated C++ editor cards while refining layout spacing and default window sizing
- add entry and button opacity animations to emphasize the primary editors and controls
- support drag-and-drop loading for .txt files with visual feedback and consolidated file import handling

## Testing
- not run (desktop Qt application)


------
https://chatgpt.com/codex/tasks/task_e_68dce0a9c69c832cb99cea93c7e1cc86