### PR TITLE
Enhance drag-and-drop experience

### DIFF
--- a/Proyecto1EstructurasDeDatos/MainWindow.h
+++ b/Proyecto1EstructurasDeDatos/MainWindow.h
@@ -21,6 +21,7 @@
 #include <QParallelAnimationGroup>
 #include <QDragEnterEvent>
 #include <QDragLeaveEvent>
+#include <QDragMoveEvent>
 #include <QDropEvent>
 #include <QResizeEvent>
 
@@ -39,6 +40,10 @@ private:
     QPlainTextEdit* inputEdit;
     QPlainTextEdit* codeEdit;
     QLabel* dropOverlayLabel;
+    QFrame* globalDropOverlay;
+    QLabel* globalDropIcon;
+    QLabel* globalDropTitle;
+    QLabel* globalDropSubtitle;
     QPushButton* loadButton;
     QPushButton* translateButton;
     QPushButton* exportButton;
@@ -66,10 +71,14 @@ private:
     void setStatusState(const QString& stateName);
     void scheduleStatusReset(int durationMs = 2200);
     void updateDropOverlayGeometry();
+    void updateGlobalDropOverlayGeometry();
+    bool mimeHasTxtFile(const QMimeData* mime) const;
+    void setDraggingVisualState(bool active);
 
 protected:
     void dragEnterEvent(QDragEnterEvent* event) override;
     void dragLeaveEvent(QDragLeaveEvent* event) override;
+    void dragMoveEvent(QDragMoveEvent* event) override;
     void dropEvent(QDropEvent* event) override;
     void resizeEvent(QResizeEvent* event) override;
 


### PR DESCRIPTION
## Summary
- allow .txt files to be dropped anywhere in the window by centralizing drag detection and move handling
- add a full-window drop overlay with refreshed styling cues during drag operations
- refactor helper logic to manage overlay geometry and visual states consistently when resizing

## Testing
- not run (UI change only)

------
https://chatgpt.com/codex/tasks/task_e_68de09406c38832c8d8af1b4a74d45c9